### PR TITLE
Paginas de detalle del ticket y pasarela de pagos agregadas

### DIFF
--- a/src/app/(solvex)/(auth)/components/TicketDetail/TicketDetail.tsx
+++ b/src/app/(solvex)/(auth)/components/TicketDetail/TicketDetail.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+function TicketDetail() {
+  return <div>TicketDetail</div>;
+}
+
+export default TicketDetail;

--- a/src/app/(solvex)/(auth)/components/TicketDetail/TicketDetail.tsx
+++ b/src/app/(solvex)/(auth)/components/TicketDetail/TicketDetail.tsx
@@ -1,7 +1,41 @@
+import { ticketData } from "@/helpers/ticketData";
+import Image from "next/image";
 import React from "react";
 
 function TicketDetail() {
-  return <div>TicketDetail</div>;
+  return (
+    <div className="w-[967px]">
+      <section className="flex justify-between pb-5">
+        <div>
+          <h3>Codigo</h3>
+          <p className="text-center border border-accent rounded-md w-[99px] p-2 ">{ticketData.codigo}</p>
+        </div>
+
+        <div>
+          <h3>Titulo</h3>
+          <p className="border border-accent rounded-md w-[597px] p-2 ">{ticketData.titulo}</p>
+        </div>
+
+        <div>
+          <h3>Estado</h3>
+          <p className="text-center text-white bg-pending rounded-md w-[194px] p-2 ">{ticketData.estado}</p>
+        </div>
+      </section>
+      <div className="pb-6">
+        <h3>Descripción</h3>
+        <p className="border border-accent rounded-md  h-[179px] p-2">{ticketData.descripcion}</p>
+      </div>
+
+      <div>
+        <h3>Imágenes adjuntas</h3>
+        <div className="border border-accent rounded-md flex justify-center items-center gap-5 p-5">
+          {ticketData.imagenesAdjuntas.map((imagen, index) => (
+            <Image key={index} src={imagen} alt={`Imagen adjunta ${index + 1}`} width={300} height={300} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export default TicketDetail;

--- a/src/app/(solvex)/(auth)/empleado/pay-plan/page.tsx
+++ b/src/app/(solvex)/(auth)/empleado/pay-plan/page.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+import React from "react";
+
+function PasarelaPagos() {
+  return (
+    <section className="m-auto w-[850px] pt-14">
+      <h2 className="text-3xl text-center text-mainText font-bold pb-3">Planes</h2>
+      <p className="text-lg pt-3">Con un perfil de administrador, tendrás acceso a herramientas exclusivas que te permitirán:</p>
+      <ol className="list-disc pl-5 pt-3 text-lg">
+        <li>Asignar usuarios al rol de soporte para que puedean atender tickets.</li>
+        <li>Visualizar estadísticas clave como resolución de incidencias .</li>
+      </ol>
+
+      <Link href={""} className="">
+        <div className="flex justify-between items-center gap-10 p-10">
+          <div className="flex flex-col justify-center items-center w-[300px] h-[200px] border border-resolved border-t-[20px] rounded-xl ">
+            <h3 className="text-4xl font-bold text-mainText pb-8">Basico</h3>
+            <h2 className="text-4xl text-resolved font-bold">$100</h2>
+            <p className="text-2xl text-resolved">1 año</p>
+          </div>
+          <div className="flex flex-col justify-center items-center w-[300px] h-[200px] border border-process border-t-[20px] rounded-xl ">
+            <h3 className="text-4xl font-bold text-mainText pb-8">Plus</h3>
+            <h2 className="text-4xl text-process font-bold">$255</h2>
+            <p className="text-2xl text-process">3 año</p>
+          </div>
+          <div className="flex flex-col justify-center items-center w-[300px] h-[200px] border border-pending border-t-[20px] rounded-xl ">
+            <h3 className="text-4xl font-bold text-mainText pb-8">Premium</h3>
+            <h2 className="text-4xl text-pending font-bold">$375</h2>
+            <p className="text-2xl text-pending">5 año</p>
+          </div>
+        </div>
+      </Link>
+    </section>
+  );
+}
+
+export default PasarelaPagos;

--- a/src/app/(solvex)/(auth)/empleado/ticket-detail/page.tsx
+++ b/src/app/(solvex)/(auth)/empleado/ticket-detail/page.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+function EmTicketDetail() {
+  return <div>EmTicketDetail</div>;
+}
+
+export default EmTicketDetail;

--- a/src/app/(solvex)/(auth)/empleado/ticket-detail/page.tsx
+++ b/src/app/(solvex)/(auth)/empleado/ticket-detail/page.tsx
@@ -1,7 +1,18 @@
 import React from "react";
+import TicketDetail from "../../components/TicketDetail/TicketDetail";
+import { otherTicketData } from "@/helpers/ticketData";
 
 function EmTicketDetail() {
-  return <div>EmTicketDetail</div>;
+  return (
+    <div className="py-5 w-[967px]">
+      <h2 className="font-bold text-2xl pb-5">Detalle de MI ticket</h2>
+      <TicketDetail />
+      <div className="w-full pt-6">
+        <h3>Fecha</h3>
+        <p className="border border-accent rounded-md  p-2">{otherTicketData.date}</p>
+      </div>
+    </div>
+  );
 }
 
 export default EmTicketDetail;

--- a/src/app/(solvex)/(auth)/helper/ticket-detail/page.tsx
+++ b/src/app/(solvex)/(auth)/helper/ticket-detail/page.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+function HelTicketDetail() {
+  return <div>HelTicketDetail</div>;
+}
+
+export default HelTicketDetail;

--- a/src/app/(solvex)/(auth)/helper/ticket-detail/page.tsx
+++ b/src/app/(solvex)/(auth)/helper/ticket-detail/page.tsx
@@ -1,7 +1,29 @@
 import React from "react";
+import TicketDetail from "../../components/TicketDetail/TicketDetail";
+import { otherTicketData } from "@/helpers/ticketData";
 
 function HelTicketDetail() {
-  return <div>HelTicketDetail</div>;
+  return (
+    <div className="py-5 w-[967px]">
+      <h2 className="font-bold text-2xl pb-5">Detalle del Ticket del Empleado</h2>
+      <TicketDetail />
+
+      <div className="flex justify-between gap-4 pt-6">
+        <div className="w-full">
+          <h3>Empleado que genero el ticket</h3>
+          <p className="border border-accent rounded-md  p-2 ">{otherTicketData.employee}</p>
+        </div>
+        <div className="w-full">
+          <h3>Fecha</h3>
+          <p className="border border-accent rounded-md  p-2">{otherTicketData.date}</p>
+        </div>
+      </div>
+
+      <button className="w-[967px] text-white text-center text-xl bg-accent rounded-md hover:opacity-70 p-2 mt-6">
+        Gestionar Ticket
+      </button>
+    </div>
+  );
 }
 
 export default HelTicketDetail;

--- a/src/helpers/ticketData.ts
+++ b/src/helpers/ticketData.ts
@@ -1,0 +1,17 @@
+export const ticketData = {
+  codigo: "COD-01",
+  titulo: "Error al guardar formulario de cliente",
+  estado: "PENDIENTE",
+  descripcion:
+    "Estaba intentando entrar al perfil de un cliente desde la lista principal, pero al hacer clic en el botón 'Ver más', me redirige a una página que muestra error 404. Probé con varios clientes y pasa lo mismo. Ya actualicé la página y cerré sesión, pero el problema sigue.",
+  imagenesAdjuntas: [
+    "https://ik.imagekit.io/SolvexCompany/ejemploImagen1.png?updatedAt=1752528893653",
+    "https://ik.imagekit.io/SolvexCompany/ejemploImagen3.jpg?updatedAt=1752528894318",
+    "https://ik.imagekit.io/SolvexCompany/ejemploImagen2.png?updatedAt=1752528894833",
+  ],
+};
+
+export const otherTicketData = {
+  employee: "Luciana Torres",
+  date: "04/07/2025",
+};


### PR DESCRIPTION
Paginas de detalle del ticket de empleado y helper agregadas. Junto con la pagina de la pasarela de pagos.
Para acceder a estas paginas deben moverse por la url, ya que las paginas de la listas de tickets todavia no estan creadas.

Detalle del ticket Helper: /helper/ticket-detail
Detalle del ticket Empleado: /empleado/ticket-detail
Pasarela de pagos: /empleado/pay-plan

Ademas hice una estructura de carpetas que podriamos usar en adelante. Fijense que les parece.